### PR TITLE
Some minor enhancements

### DIFF
--- a/config.php
+++ b/config.php
@@ -5,6 +5,9 @@
  *
  * Ensure you have done every other steps described on
  * https://github.com/Bioshox/Raspcontrol/wiki/Enable-URL-Rewriting#configure-your-web-server
+ * As that original URL is dead, here are some alternatives:
+ * https://github.com/moifort/Raspcontrol-ArchLinux/wiki/Enable-URL-Rewriting
+ * https://menzerath.eu/artikel/raspberry-pi-raspcontrol-installation-funktionen/
  */
 $rewriting = false;
 

--- a/lib/cpu.php
+++ b/lib/cpu.php
@@ -47,7 +47,7 @@ class CPU {
 
         $cpuDetails = $ssh->shell_exec_noauth('ps -e -o pcpu,user,args --sort=-pcpu | sed "/^ 0.0 /d" | head -' . self::$DETAIL_LINE_COUNT);
 
-        $result['degrees'] = round($currenttemp / 1000);
+        $result['degrees'] = round($currenttemp / 1000, 1);
         $result['percentage'] = round($result['degrees'] / self::$MaxTemp * 100);
 
         if ($result['percentage'] >= '80')

--- a/lib/network.php
+++ b/lib/network.php
@@ -6,11 +6,18 @@ class Network {
 
     public static function connections() {
         global $ssh;
-        $connections = $ssh->shell_exec_noauth("netstat -nta --inet | wc -l");
-        $connections--;
+        $connections = $ssh->shell_exec_noauth("netstat -nta --inet | grep -e '\(tcp\|udp\)' | wc -l");
+        $established = $ssh->shell_exec_noauth("netstat -nta --inet | grep ESTABLISHED | wc -l");
+        $listening = $ssh->shell_exec_noauth("netstat -nta --inet | grep LISTEN | wc -l");
+        $opening = $ssh->shell_exec_noauth("netstat -nta --inet | grep SYN | wc -l");
+        $closing = $ssh->shell_exec_noauth("netstat -nta --inet | grep -e '\(CLOS\|WAIT\|LAST\)' | wc -l");
 
         return array(
             'connections' => substr($connections, 0, -1),
+            'established' => substr($established, 0, -1),
+            'listening' => substr($listening, 0, -1),
+            'opening' => substr($opening, 0, -1),
+            'closing' => substr($closing, 0, -1),
             'alert' => ($connections >= 50 ? 'warning' : 'success')
         );
     }

--- a/lib/power.php
+++ b/lib/power.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace lib;
+
+class Power {
+
+    public static function power() {
+        global $ssh;
+        $amps = $ssh->shell_exec_noauth('cat /sys/devices/platform/sunxi-i2c.0/i2c-0/0-0034/axp20-supplyer.28/power_supply/ac/current_now');  // µA
+        $volts = $ssh->shell_exec_noauth('cat /sys/devices/platform/sunxi-i2c.0/i2c-0/0-0034/axp20-supplyer.28/power_supply/ac/voltage_now'); // µV
+        $watts = round($amps * $volts / pow(10,12), 1);
+        if ( $watts > 8 ) $alert = 'alert';
+        elseif ( $watts > 6 ) $alert = 'warning';
+        else $alert = 'success';
+
+        $result = array(
+            'milliampere' => round($amps/1000),
+            'voltage' => round($volts/1000000, 1),
+            'watts' => $watts,
+            'alert' => $alert
+        );
+
+        return $result;
+    }
+
+}
+
+?>

--- a/lib/storage.php
+++ b/lib/storage.php
@@ -20,6 +20,7 @@ class Storage {
             $result[$i]['total'] = self::kConv($available + $used);
             $result[$i]['free'] = self::kConv($available);
             $result[$i]['used'] = self::kConv($used);
+            $result[$i]['reserved'] = self::kConv($size - $available - $used); // system reserved space
             $result[$i]['format'] = $type;
 
             $result[$i]['percentage'] = rtrim($percentage, '%');

--- a/lib/storage.php
+++ b/lib/storage.php
@@ -17,9 +17,9 @@ class Storage {
             list($fs, $type, $size, $used, $available, $percentage, $mounted) = $drivedetails[0];
 
             $result[$i]['name'] = $mounted;
-            $result[$i]['total'] = self::kConv($size);
+            $result[$i]['total'] = self::kConv($available + $used);
             $result[$i]['free'] = self::kConv($available);
-            $result[$i]['used'] = self::kConv($size - $available);
+            $result[$i]['used'] = self::kConv($used);
             $result[$i]['format'] = $type;
 
             $result[$i]['percentage'] = rtrim($percentage, '%');

--- a/pages/details.php
+++ b/pages/details.php
@@ -3,6 +3,7 @@
 namespace lib;
 
 use lib\Uptime;
+use lib\Power;
 use lib\Memory;
 use lib\CPU;
 use lib\Storage;
@@ -12,6 +13,7 @@ use lib\Users;
 use lib\Temp;
 
 $uptime = Uptime::uptime();
+$power = Power::power();
 $ram = Memory::ram();
 $swap = Memory::swap();
 $cpu = CPU::cpu();
@@ -85,6 +87,12 @@ function shell_to_html_table_result($shellExecOutput) {
             <td class="check"><i class="icon-time"></i> Uptime</td>
             <td class="icon"></td>
             <td class="infos"><?php echo $uptime; ?></td>
+        </tr>
+
+        <tr id="check-power">
+            <td class="check"><i class="icon-road"></i> Power usage</td>
+            <td class="icon"><?php echo icon_alert($power['alert']); ?></td>
+            <td class="infos"><?php echo $power['voltage']; ?> V &middot; <?php echo $power['milliampere']; ?> mA &middot; <?php echo $power['watts']; ?> W</td>
         </tr>
 
         <tr id="check-ram">

--- a/pages/details.php
+++ b/pages/details.php
@@ -158,7 +158,7 @@ function shell_to_html_table_result($shellExecOutput) {
                 IP: <span class="text-info"><?php echo Rbpi::internalIp(); ?></span> [internal] &middot;
                 <span class="text-info"><?php echo Rbpi::externalIp(); ?></span> [external]
                 <br />received: <strong><?php echo $net_eth['down']; ?>Mb</strong> &middot; sent: <strong><?php echo $net_eth['up']; ?>Mb</strong> &middot; total: <?php echo $net_eth['total']; ?>Mb
-                <br />connections: <?php echo $net_connections['connections']; ?>
+                <br />connections: <?php echo $net_connections['connections']; ?> (<?php echo $net_connections['established']; ?> established, <?php echo $net_connections['listening']; ?> listening, <?php echo $net_connections['opening']; ?> opening, <?php echo $net_connections['closing'] ?> closing)
             </td>
         </tr>
 

--- a/pages/details.php
+++ b/pages/details.php
@@ -152,7 +152,7 @@ function shell_to_html_table_result($shellExecOutput) {
               <div class="progress">
                 <div class="bar bar-', $hdd[$i]['alert'], '" style="width: ', $hdd[$i]['percentage'], '%;">', $hdd[$i]['percentage'], '%</div>
               </div>
-              free: <span class="text-success">', $hdd[$i]['free'], 'b</span> &middot; used: <span class="text-warning">', $hdd[$i]['used'], 'b</span> &middot; total: ', $hdd[$i]['total'], 'b &middot; format: ', $hdd[$i]['format'], '
+              <abbr title="free and usable space">free</abbr>: <span class="text-success">', $hdd[$i]['free'], 'b</span> &middot; <abbr title="occupied by data">used</abbr>: <span class="text-warning">', $hdd[$i]['used'], 'b</span> &middot; <abbr title="usable space, occupied or free">total</abbr>: ', $hdd[$i]['total'], 'b (+ ', $hdd[$i]['reserved'], 'b <abbr title="system reserved space (not available for data)">reserved</abbr>) &middot; format: ', $hdd[$i]['format'], '
             </td>
           </tr>
           ', ($i == sizeof($hdd) - 1) ? null : '<tr class="storage">';
@@ -166,7 +166,7 @@ function shell_to_html_table_result($shellExecOutput) {
                 IP: <span class="text-info"><?php echo Rbpi::internalIp(); ?></span> [internal] &middot;
                 <span class="text-info"><?php echo Rbpi::externalIp(); ?></span> [external]
                 <br />received: <strong><?php echo $net_eth['down']; ?>Mb</strong> &middot; sent: <strong><?php echo $net_eth['up']; ?>Mb</strong> &middot; total: <?php echo $net_eth['total']; ?>Mb
-                <br />connections: <?php echo $net_connections['connections']; ?> (<?php echo $net_connections['established']; ?> established, <?php echo $net_connections['listening']; ?> listening, <?php echo $net_connections['opening']; ?> opening, <?php echo $net_connections['closing'] ?> closing)
+                <br />connections: <?php echo $net_connections['connections']; ?> (<?php echo $net_connections['established']; ?> <abbr title="open and active connections">established</abbr>, <?php echo $net_connections['listening']; ?> <abbr title="waiting for incoming connections">listening</abbr>, <?php echo $net_connections['opening']; ?> <abbr title="connections about to be established">opening</abbr>, <?php echo $net_connections['closing'] ?> <abbr title="connections just closed or about to be closed">closing</abbr>)
             </td>
         </tr>
 


### PR DESCRIPTION
This pull requests consists of <s>2</s> <s>3</s> 4 commits:
1. CPU temperature: include centi-grades (as suggested with issue #2)
2. network stats: connections
   - changed calculation of amount (original code simply assumed one header line, in my case it were two – leading to an incorrect number. As `inet` consists of TCP and UDP, new code simply greps for those and applies `wc -l` directly on the result. Should be more accurate)
   - included details on connections: how many are currently active (established), in close (closed or in the process of being close), or simply listening
3. included power consumption stats (as suggested with issue #2)
4. fixed disk space calculation
   - total now reflects "total usable space" (used+free). Previous code didn't consider some blocks (usually 5%) of the file system are reserved, see e.g. [how to interpret the linux df cmd result](http://stackoverflow.com/q/17413336/2533433)
   - accordingly, "used" is now taken directly from `df` output (counter-correction)
   - example of "confusing output" of the previous code: one of my Bananas has a 128GB SSD, two partitions. The larger is sized 109GB, and had ~530MB used – which were shown as over 6GB. Got me confused :)

One more thing I'd love to have here is a "hover" element showing the top-5 active connections, but I haven't implemented that (yet).

I hope you like these updates. I tried to stick to your coding style, so you should be able to easily verify my changes. Looking forward to see them integrated!
